### PR TITLE
Filter withRpc

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -24,6 +24,7 @@ use BlastCloud\Chassis\Helpers\File;
  * @method $this withoutQuery()
  * @method $this withQueryKey(string $key)
  * @method $this withQueryKeys(array $keys)
+ * @method $this withRpc(string $endpoint, string $method, array $params, ?string $id)
  * @method $this withJson(array $values, bool $exclusive = false)
  * @method $this withForm(array $form, bool $exclusive = false)
  * @method $this withFormField(string $key, $value)

--- a/src/Filters/WithJson.php
+++ b/src/Filters/WithJson.php
@@ -4,9 +4,13 @@ namespace BlastCloud\Guzzler\Filters;
 
 use BlastCloud\Chassis\Interfaces\With;
 use BlastCloud\Chassis\Filters\Base;
+use BlastCloud\Guzzler\Traits\RecursiveSort;
 
 class WithJson extends Base implements With
 {
+
+    use RecursiveSort;
+
     /** @var string */
     protected $json = '';
     protected $exclusive = false;
@@ -17,24 +21,6 @@ class WithJson extends Base implements With
         // Pre-sort so it only needs to be done once.
         $this->json = $json;
         $this->sort($this->json);
-    }
-
-    // Determine if the passed array has any non-incrementing keys; associative array
-    protected function isAssoc(array $arr)
-    {
-        if ([] === $arr) return false;
-        return array_keys($arr) !== range(0, count($arr) - 1);
-    }
-
-    // Recursively sort by keys and values
-    protected function sort(&$array) {
-        foreach ($array as &$value) {
-            if (is_array($value)) $this->sort($value);
-        }
-
-        return $this->isAssoc($array)
-            ? ksort($array)
-            : sort($array);
     }
 
     public function __invoke(array $history): array

--- a/src/Filters/WithRpc.php
+++ b/src/Filters/WithRpc.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace BlastCloud\Guzzler\Filters;
+
+use BlastCloud\Chassis\Interfaces\With;
+use BlastCloud\Chassis\Filters\Base;
+use BlastCloud\Guzzler\Traits\RecursiveSort;
+use GuzzleHttp\Psr7\Uri;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\UriInterface;
+
+class WithRpc extends Base implements With
+{
+
+    use RecursiveSort;
+
+    const JSON_RPC_VERSION = '2.0';
+
+    /** @var UriInterface */
+    protected $url = '';
+
+    /** @var array */
+    protected $json = [];
+
+    public function withRpc(string $url, string $method, array $params, ?string $id = null)
+    {
+        $this->url = Uri::fromParts(parse_url($url));
+
+        $json = [
+            'jsonrpc' => self::JSON_RPC_VERSION,
+            'method' => $method,
+            'params' => $params,
+        ];
+
+        if ($id) {
+            $json['id'] = $id;
+        }
+
+        $this->json = $json;
+
+        $this->sort($this->json);
+    }
+
+    public function __invoke(array $history): array
+    {
+        return array_filter($history, function ($call) {
+
+            /** @var RequestInterface $request */
+            $request = $call['request'];
+
+            $isEndpointCorrect = $request->getMethod() === 'POST'
+                && $request->getUri()->getPath() === $this->url->getPath();
+
+            $body = json_decode($request->getBody(), true);
+
+            $this->sort($body);
+
+            $j1 = json_encode($body);
+            $j2 = json_encode($this->json);
+
+            $isJsonCorrect = $j1 === $j2;
+
+            return $isEndpointCorrect && $isJsonCorrect;
+        });
+    }
+
+    public function __toString(): string
+    {
+        return "JSON-RPC 2.0: (POST {$this->url}) "
+            .json_encode($this->json, JSON_PRETTY_PRINT);
+    }
+}

--- a/src/Traits/RecursiveSort.php
+++ b/src/Traits/RecursiveSort.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace BlastCloud\Guzzler\Traits;
+
+trait RecursiveSort
+{
+    // Determine if the passed array has any non-incrementing keys; associative array
+    protected function isAssoc(array $arr)
+    {
+        if ([] === $arr) return false;
+        return array_keys($arr) !== range(0, count($arr) - 1);
+    }
+
+    // Recursively sort by keys and values
+    protected function sort(&$array) {
+        foreach ($array as &$value) {
+            if (is_array($value)) $this->sort($value);
+        }
+
+        return $this->isAssoc($array)
+            ? ksort($array)
+            : sort($array);
+    }
+}

--- a/tests/Filters/WithRpcTest.php
+++ b/tests/Filters/WithRpcTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace tests\Filters;
+
+
+use BlastCloud\Guzzler\Expectation;
+use BlastCloud\Guzzler\Filters\WithRpc;
+use BlastCloud\Guzzler\UsesGuzzler;
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\RequestOptions;
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\TestCase;
+use tests\ExceptionMessageRegex;
+
+class WithRpcTest extends TestCase
+{
+    use UsesGuzzler, ExceptionMessageRegex;
+
+    /** @var Client */
+    public $client;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->client = $this->guzzler->getClient();
+    }
+
+    public function testWithRpc()
+    {
+        $url = '/rpc';
+        $id = '123';
+        $method = 'test-method';
+        $params = [
+            'a' => 1,
+            'b' => 2,
+        ];
+
+        $this->guzzler->queueMany(new Response(), 2);
+
+        $this->guzzler->expects($this->atLeastOnce())
+            ->withRpc($url, $method, $params, $id);
+
+        $this->client->post($url, [
+            RequestOptions::JSON => $this->makeJsonRPCRequest($method, $params, $id),
+        ]);
+
+        $this->client->post($url, [
+            RequestOptions::JSON => $this->makeJsonRPCRequest($method, [], $id),
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->{self::$regexMethodName}("/JSON-RPC 2.0/");
+        $this->guzzler->assertLast(function (Expectation $e) {
+            return $e->withRpc('/rpc', 'test-method', ['a' => 1, 'b' => 2], 123);
+        });
+    }
+
+    /**
+     * @param $method
+     * @param $params
+     * @param $id
+     * @return array
+     */
+    protected function makeJsonRPCRequest($method, $params, $id)
+    {
+        return [
+            'jsonrpc' => WithRpc::JSON_RPC_VERSION,
+            'method' => $method,
+            'params' => $params,
+            'id' => $id,
+        ];
+    }
+}


### PR DESCRIPTION
#12 

Unfortunately, I could not make the correct name of the method due to the peculiarities of filter connecting mechanism.

--- 

Example of error output:
```
Expectation: 
-----------------------------
JSON-RPC 2.0: (POST /rpc) {
    "id": "123",
    "jsonrpc": "2.0",
    "method": "test-method",
    "params": {
        "a": 1,
        "b": 2
    }
}
```